### PR TITLE
feat(home): update icons (lucide), spacing, outcomes section; add AI …

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { CTA } from "@/components/marketing/cta";
 import { LogoCloud } from "@/components/marketing/logo-cloud";
 import { CaseStudyTeasers } from "@/components/marketing/case-study-teasers";
+import { Clock, TrendingUp, BarChart2, PenLine } from "lucide-react";
 const FeatureBlocks = dynamic(
   () =>
     import("@/components/marketing/features").then((m) => ({
@@ -17,13 +18,13 @@ const Metrics = dynamic(
     })),
   { ssr: true },
 );
-const Testimonial = dynamic(
-  () =>
-    import("@/components/marketing/testimonial").then((m) => ({
-      default: m.Testimonial,
-    })),
-  { ssr: true },
-);
+// const Testimonial = dynamic(
+//   () =>
+//     import("@/components/marketing/testimonial").then((m) => ({
+//       default: m.Testimonial,
+//     })),
+//   { ssr: true },
+// );
 import { SectionHeader } from "@/components/section-header";
 
 export default function Home() {
@@ -31,22 +32,72 @@ export default function Home() {
     <div className="min-h-[100svh]">
       <MotionHero />
       <main id="content" role="main" className="container mx-auto px-6 md:px-8">
-        <LogoCloud className="mt-16" />
+        <LogoCloud className="mt-16 mb-8" />
         <SectionHeader
           eyebrow="Solutions"
           title="Build. Automate. Scale."
-          subtitle="From strategy to managed AI, we deliver measurable impact.
-"
+          subtitle="From strategy to managed AI, we deliver measurable impact."
+          className="mt-12"
         />
         <FeatureBlocks />
         <Metrics />
         <SectionHeader
-          eyebrow="Proof"
+          eyebrow="What You Can Expect"
           title="Customers win time back"
           subtitle="Clinics, logistics, and e‑commerce teams reclaim 10+ hours weekly."
+          className="mt-16"
         />
+        <div className="grid md:grid-cols-2 gap-6 mt-6 mb-12">
+          <div className="glass rounded-xl p-6 flex items-start gap-4">
+            <Clock
+              className="h-6 w-6 text-cyan-400"
+              style={{ filter: "drop-shadow(0 0 10px rgba(0,229,255,0.45))" }}
+              aria-hidden
+            />
+            <p className="text-muted-foreground">
+              Save 5–10 hours per week by automating repetitive tasks across
+              support, sales, and reporting. Shift time to higher‑value work
+              without growing headcount.
+            </p>
+          </div>
+          <div className="glass rounded-xl p-6 flex items-start gap-4">
+            <TrendingUp
+              className="h-6 w-6 text-violet-400"
+              style={{ filter: "drop-shadow(0 0 10px rgba(139,92,246,0.45))" }}
+              aria-hidden
+            />
+            <p className="text-muted-foreground">
+              Speed up sales cycles with consistent follow‑ups, lead
+              qualification, and CRM hygiene—improving win rates while reducing
+              manual data entry.
+            </p>
+          </div>
+          <div className="glass rounded-xl p-6 flex items-start gap-4">
+            <BarChart2
+              className="h-6 w-6 text-sky-400"
+              style={{ filter: "drop-shadow(0 0 10px rgba(0,229,255,0.45))" }}
+              aria-hidden
+            />
+            <p className="text-muted-foreground">
+              Make faster, better decisions with live dashboards showing
+              pipeline, revenue, and operational KPIs—no spreadsheet wrangling
+              required.
+            </p>
+          </div>
+          <div className="glass rounded-xl p-6 flex items-start gap-4">
+            <PenLine
+              className="h-6 w-6 text-cyan-400"
+              style={{ filter: "drop-shadow(0 0 10px rgba(0,229,255,0.45))" }}
+              aria-hidden
+            />
+            <p className="text-muted-foreground">
+              Publish consistent, on‑brand content faster with AI‑assisted
+              drafts and a lightweight review process—reducing revision cycles.
+            </p>
+          </div>
+        </div>
         <CaseStudyTeasers />
-        <Testimonial />
+        {/** <Testimonial /> */}
         <CTA className="my-24" />
       </main>
     </div>

--- a/components/marketing/features.tsx
+++ b/components/marketing/features.tsx
@@ -1,5 +1,12 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Cpu, Bot, BarChart3, Workflow } from "lucide-react";
+import {
+  Cpu,
+  Bot,
+  BarChart3,
+  Workflow,
+  Compass,
+  GraduationCap,
+} from "lucide-react";
 
 const features = [
   {
@@ -22,6 +29,16 @@ const features = [
     title: "Content Assistant",
     body: "Streamlines content creation from brief to publication with AI-powered writing, brand compliance checks, and approval workflows. Typical results: 40% faster content production, consistent brand voice, and 60% reduction in revision cycles. Includes templates, style guides, and multi-channel publishing.",
   },
+  {
+    icon: Compass,
+    title: "AI Readiness & Roadmap",
+    body: "Assess processes, data, and tooling to identify high-ROI AI use cases. Deliver a phased adoption plan with risk controls, stack recommendations, and a 90-day execution map. Typical results: clarity on 3–5 pilots, 2-week assessment with quick wins.",
+  },
+  {
+    icon: GraduationCap,
+    title: "AI Skills Training & Workshops",
+    body: "Hands-on enablement for teams: prompt engineering, workflow design, QA guardrails, and ethical usage. Typical results: faster adoption, consistent outputs, and 5–10 hours saved weekly across functions.",
+  },
 ];
 
 export function FeatureBlocks() {
@@ -30,9 +47,15 @@ export function FeatureBlocks() {
       {features.map((f) => (
         <Card key={f.title} className="neon-border bg-surface/60">
           <CardHeader>
-            <div className="flex items-center gap-3">
-              <f.icon className="text-[var(--accent-2)]" />
-              <CardTitle className="font-display">{f.title}</CardTitle>
+            <div className="flex items-center gap-4">
+              <f.icon
+                className="h-12 w-12 text-cyan-400"
+                style={{ filter: "drop-shadow(0 0 10px rgba(0,229,255,0.45))" }}
+                aria-hidden
+              />
+              <CardTitle className="font-display text-xl md:text-2xl">
+                {f.title}
+              </CardTitle>
             </div>
           </CardHeader>
           <CardContent>

--- a/components/marketing/logo-cloud.tsx
+++ b/components/marketing/logo-cloud.tsx
@@ -1,29 +1,102 @@
-import Image from "next/image";
+import {
+  MessageSquare,
+  Headphones,
+  FileText,
+  Receipt,
+  BarChart2,
+  Activity,
+  PenLine,
+  Edit3,
+} from "lucide-react";
 
 export function LogoCloud({ className = "" }: { className?: string }) {
+  const iconSize = "h-12 w-12";
+  const glow = {
+    filter: "drop-shadow(0 0 10px rgba(0,229,255,0.45))",
+  } as const;
+  const purpleGlow = {
+    filter: "drop-shadow(0 0 10px rgba(139,92,246,0.45))",
+  } as const;
+
   const logos = [
-    { name: "Vercel", src: "/vercel.svg" },
-    { name: "Next.js", src: "/next.svg" },
-    { name: "Window", src: "/window.svg" },
-    { name: "Globe", src: "/globe.svg" },
+    {
+      name: "Support Copilot icon",
+      render: () => (
+        <MessageSquare
+          className={`${iconSize} text-cyan-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+      fallback: () => (
+        <Headphones
+          className={`${iconSize} text-cyan-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+    },
+    {
+      name: "Lead to Invoice icon",
+      render: () => (
+        <FileText
+          className={`${iconSize} text-violet-400`}
+          style={purpleGlow}
+          aria-hidden
+        />
+      ),
+      fallback: () => (
+        <Receipt
+          className={`${iconSize} text-violet-400`}
+          style={purpleGlow}
+          aria-hidden
+        />
+      ),
+    },
+    {
+      name: "Dashboards icon",
+      render: () => (
+        <BarChart2
+          className={`${iconSize} text-sky-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+      fallback: () => (
+        <Activity
+          className={`${iconSize} text-sky-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+    },
+    {
+      name: "Content Assistant icon",
+      render: () => (
+        <PenLine
+          className={`${iconSize} text-cyan-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+      fallback: () => (
+        <Edit3
+          className={`${iconSize} text-cyan-400`}
+          style={glow}
+          aria-hidden
+        />
+      ),
+    },
   ];
   return (
-    <div
-      className={`grid grid-cols-2 md:grid-cols-4 gap-6 opacity-70 ${className}`}
-    >
+    <div className={`grid grid-cols-2 md:grid-cols-4 gap-6 ${className}`}>
       {logos.map((l) => (
         <div
           key={l.name}
-          className="glass rounded-xl p-4 flex items-center justify-center"
-          aria-label={`${l.name} logo`}
+          className="glass rounded-xl p-6 flex items-center justify-center"
+          aria-label={l.name}
         >
-          <Image
-            src={l.src}
-            alt={l.name}
-            width={80}
-            height={24}
-            loading="lazy"
-          />
+          {l.render()}
         </div>
       ))}
     </div>


### PR DESCRIPTION
- Replaced the four homepage logos with lucide icons and neon accents, evenly sized at h-12 w-12 with glow.
- Adjusted spacing: added bottom margin to icons, increased top margin on “Solutions”, added breathing room around the outcomes section.
- Replaced “PROOF” with “What You Can Expect”; added 4 outcome bullets with icons; hid the testimonial.
- Expanded solutions: added “AI Readiness & Roadmap” and “AI Skills Training & Workshops”; ensured icons are consistent.
- Built and committed.