### PR TITLE
feat(contact): server‑side email (Resend + SendGrid), update “email us”

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,26 @@ Stack: Next.js (App Router, TS), Tailwind v4, shadcn/ui, Framer Motion, MDX, nex
 
 ## Contact form
 
-- Default: Formspree POST to placeholder endpoint in `app/(routes)/contact/page.tsx`
-- Honeypot field `website`, debounce and toasts included
-- Fallback: `mailto:info@lazycreations.ai`
-- Env: set `NEXT_PUBLIC_FORMSPREE_ENDPOINT` to your Formspree endpoint
-- Optional API: `app/api/contact/route.ts` with Resend (disabled by default)
-  - Set `RESEND_API_KEY` and switch the form `fetch` to `/api/contact`
+- Server-side email via Resend (primary) with optional SendGrid fallback.
+- Honeypot field `website`, debounce, and strict success handling.
+- Success toast only shown when provider responds 200/201.
+- Configure env vars:
+  - `RESEND_API_KEY`
+  - `EMAIL_FROM` (e.g., no-reply@lazycreations.ai)
+  - `EMAIL_TO` (e.g., admin@lazycreations.ai)
+  - Optional SendGrid: `SENDGRID_API_KEY`, `SENDGRID_FROM`, `SENDGRID_TO`
+
+### Deliverability
+
+- SPF: `v=spf1 include:_spf.resend.com ~all` (or SendGrid: include:sendgrid.net)
+- DKIM: Add CNAMEs provided by the provider
+- DMARC: `v=DMARC1; p=none; rua=mailto:dmarc@lazycreations.ai`
+- Verify your domain in Resend (and SendGrid if used)
+- Use `EMAIL_FROM` on the verified domain only
+
+### Health
+
+- Dev-only health check: `GET /api/health/email` returns whether required envs are present
 
 ## SEO
 

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -20,8 +20,13 @@ const lastSubmissionByIp = new Map<string, number>();
 function getClientIp(req: Request): string {
   const xf = req.headers.get("x-forwarded-for");
   if (xf) return xf.split(",")[0]?.trim() || "unknown";
-  const ra = (req as any).ip || (req as any).socket?.remoteAddress;
-  return typeof ra === "string" ? ra : "unknown";
+  type NodeRequestLike = {
+    ip?: string | null;
+    socket?: { remoteAddress?: string | null } | null;
+  };
+  const nodeReq = req as unknown as NodeRequestLike;
+  const ra = nodeReq.ip ?? nodeReq.socket?.remoteAddress ?? null;
+  return typeof ra === "string" && ra.length > 0 ? ra : "unknown";
 }
 
 function buildEmailHtml(

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { headers as nextHeaders } from "next/headers";
 import { z } from "zod";
 import { Resend } from "resend";
-import { render } from "@react-email/render";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import ContactSubmissionEmail from "@/emails/ContactSubmission";
 import sgMail from "@sendgrid/mail";
 
@@ -118,7 +119,9 @@ export async function POST(req: Request) {
       origin,
       logoUrl: process.env.EMAIL_LOGO_URL,
     });
-    const html = render(reactEmail);
+    const html = renderToStaticMarkup(
+      React.createElement(React.Fragment, null, reactEmail),
+    );
     const text = buildEmailText(data, origin);
 
     const emailFrom = process.env.EMAIL_FROM ?? "no-reply@lazycreations.ai";

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from "next/server";
 import { headers as nextHeaders } from "next/headers";
 import { z } from "zod";
 import { Resend } from "resend";
-import React from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import ContactSubmissionEmail from "@/emails/ContactSubmission";
 import sgMail from "@sendgrid/mail";
 
@@ -119,9 +117,7 @@ export async function POST(req: Request) {
       origin,
       logoUrl: process.env.EMAIL_LOGO_URL,
     });
-    const html = renderToStaticMarkup(
-      React.createElement(React.Fragment, null, reactEmail),
-    );
+    const html = buildEmailHtml(data, origin);
     const text = buildEmailText(data, origin);
 
     const emailFrom = process.env.EMAIL_FROM ?? "no-reply@lazycreations.ai";

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,19 +1,175 @@
-// Disabled by default. Enable by setting RESEND_API_KEY and switching the contact form endpoint.
 import { NextResponse } from "next/server";
+import { headers as nextHeaders } from "next/headers";
+import { z } from "zod";
+import { Resend } from "resend";
+import sgMail from "@sendgrid/mail";
+
+const BodySchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  budget: z.string().optional(),
+  message: z.string().min(10),
+  website: z.string().optional(), // honeypot
+});
+
+const lastSubmissionByIp = new Map<string, number>();
+
+function getClientIp(req: Request): string {
+  const xf = req.headers.get("x-forwarded-for");
+  if (xf) return xf.split(",")[0]?.trim() || "unknown";
+  const ra = (req as any).ip || (req as any).socket?.remoteAddress;
+  return typeof ra === "string" ? ra : "unknown";
+}
+
+function buildEmailHtml(
+  data: z.infer<typeof BodySchema>,
+  origin: string,
+): string {
+  return `
+  <div style="font-family:Inter,Segoe UI,Arial,sans-serif;line-height:1.6;font-size:14px;color:#0f172a">
+    <h2 style="margin:0 0 12px 0;color:#111827">New Contact Submission</h2>
+    <p style="margin:0 0 12px 0">From: <strong>${escapeHtml(data.name)}</strong> &lt;${escapeHtml(
+      data.email,
+    )}&gt;</p>
+    ${data.company ? `<p style="margin:0 0 12px 0">Company: ${escapeHtml(data.company)}</p>` : ""}
+    ${data.phone ? `<p style="margin:0 0 12px 0">Phone: ${escapeHtml(data.phone)}</p>` : ""}
+    ${data.budget ? `<p style="margin:0 0 12px 0">Budget: ${escapeHtml(data.budget)}</p>` : ""}
+    <p style="margin:0 0 12px 0">Message:</p>
+    <div style="white-space:pre-wrap;border:1px solid #e5e7eb;border-radius:8px;padding:12px;background:#f9fafb;color:#111827">${escapeHtml(
+      data.message,
+    )}</div>
+    <p style="margin-top:16px;color:#6b7280;font-size:12px">Origin: ${escapeHtml(
+      origin,
+    )}</p>
+  </div>`;
+}
+
+function buildEmailText(
+  data: z.infer<typeof BodySchema>,
+  origin: string,
+): string {
+  return [
+    `New Contact Submission`,
+    `From: ${data.name} <${data.email}>`,
+    data.company ? `Company: ${data.company}` : undefined,
+    data.phone ? `Phone: ${data.phone}` : undefined,
+    data.budget ? `Budget: ${data.budget}` : undefined,
+    `Message:`,
+    data.message,
+    ``,
+    `Origin: ${origin}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
 
 export async function POST(req: Request) {
   try {
-    if (!process.env.RESEND_API_KEY) {
+    const h = await nextHeaders();
+    const origin = h.get("origin") ?? "unknown";
+    const ip = getClientIp(req);
+    const now = Date.now();
+    const last = lastSubmissionByIp.get(ip) ?? 0;
+    if (now - last < 15_000) {
       return NextResponse.json(
-        { ok: false, error: "Disabled" },
-        { status: 503 },
+        { ok: false, error: "Too many requests. Please wait a moment." },
+        { status: 429 },
       );
     }
-    await req.json();
-    // Example shape: { name, company, email, phone, budget, message }
-    // TODO: Send email via Resend SDK here.
-    return NextResponse.json({ ok: true });
-  } catch {
-    return NextResponse.json({ ok: false }, { status: 500 });
+
+    const json = await req.json();
+    const parsed = BodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: "Invalid input." },
+        { status: 400 },
+      );
+    }
+    const data = parsed.data;
+
+    // Honeypot rejection
+    if (data.website && data.website.trim() !== "") {
+      return NextResponse.json({ ok: true });
+    }
+
+    lastSubmissionByIp.set(ip, now);
+
+    const subject = `New Contact Form — ${data.name}`;
+    const html = buildEmailHtml(data, origin);
+    const text = buildEmailText(data, origin);
+
+    const emailFrom = process.env.EMAIL_FROM ?? "no-reply@lazycreations.ai";
+    const emailTo = process.env.EMAIL_TO ?? "admin@lazycreations.ai";
+
+    if (process.env.RESEND_API_KEY) {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const { error } = await resend.emails.send({
+        from: emailFrom,
+        to: [emailTo],
+        replyTo: data.email,
+        subject,
+        html,
+        text,
+      });
+      if (error) {
+        console.error("contact email error (resend)", {
+          provider: "resend",
+          message: error.message,
+        });
+        return NextResponse.json(
+          { ok: false, error: "Email provider error (Resend)." },
+          { status: 500 },
+        );
+      }
+      return NextResponse.json({ ok: true });
+    }
+
+    if (process.env.SENDGRID_API_KEY) {
+      try {
+        sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+        await sgMail.send({
+          to: emailTo,
+          from: process.env.SENDGRID_FROM ?? emailFrom,
+          replyTo: data.email,
+          subject,
+          html,
+          text,
+        });
+        return NextResponse.json({ ok: true });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        console.error("contact email error (sendgrid)", {
+          provider: "sendgrid",
+          message: msg,
+        });
+        return NextResponse.json(
+          { ok: false, error: "Email provider error (SendGrid)." },
+          { status: 500 },
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { ok: false, error: "Email provider not configured." },
+      { status: 503 },
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "Unknown error";
+    console.error("contact email route error", { message: msg });
+    return NextResponse.json(
+      { ok: false, error: "Failed to process request." },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -108,17 +108,17 @@ export async function POST(req: Request) {
     lastSubmissionByIp.set(ip, now);
 
     const subject = `New Contact Form — ${data.name}`;
-    const html = render(
-      ContactSubmissionEmail({
-        name: data.name,
-        email: data.email,
-        company: data.company,
-        phone: data.phone,
-        budget: data.budget,
-        message: data.message,
-        origin,
-      }),
-    );
+    const reactEmail = ContactSubmissionEmail({
+      name: data.name,
+      email: data.email,
+      company: data.company,
+      phone: data.phone,
+      budget: data.budget,
+      message: data.message,
+      origin,
+      logoUrl: process.env.EMAIL_LOGO_URL,
+    });
+    const html = render(reactEmail);
     const text = buildEmailText(data, origin);
 
     const emailFrom = process.env.EMAIL_FROM ?? "no-reply@lazycreations.ai";
@@ -131,7 +131,7 @@ export async function POST(req: Request) {
         to: [emailTo],
         replyTo: data.email,
         subject,
-        html,
+        react: reactEmail,
         text,
       });
       if (error) {

--- a/app/api/health/email/route.ts
+++ b/app/api/health/email/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const hasResend = Boolean(process.env.RESEND_API_KEY);
+  const hasSendgrid = Boolean(process.env.SENDGRID_API_KEY);
+  const from = process.env.EMAIL_FROM ?? process.env.SENDGRID_FROM ?? null;
+  const to = process.env.EMAIL_TO ?? process.env.SENDGRID_TO ?? null;
+  return NextResponse.json({
+    hasResend,
+    hasSendgrid,
+    fromConfigured: Boolean(from),
+    toConfigured: Boolean(to),
+    env: process.env.NODE_ENV,
+  });
+}

--- a/components/marketing/cta.tsx
+++ b/components/marketing/cta.tsx
@@ -18,7 +18,7 @@ export function CTA({ className = "" }: { className?: string }) {
           </Link>
         </Button>
         <Button asChild variant="outline" size="lg">
-          <Link href="mailto:info@lazycreations.ai" data-cta="cta-mailto">
+          <Link href="mailto:admin@lazycreations.ai" data-cta="cta-mailto">
             Or email us
           </Link>
         </Button>

--- a/emails/ContactSubmission.tsx
+++ b/emails/ContactSubmission.tsx
@@ -1,17 +1,4 @@
 import React from "react";
-import {
-  Html,
-  Head,
-  Preview,
-  Body,
-  Container,
-  Section,
-  Heading,
-  Text,
-  Img,
-  Hr,
-  Link,
-} from "@react-email/components";
 
 type Props = {
   name: string;
@@ -36,126 +23,116 @@ export default function ContactSubmissionEmail({
 }: Props) {
   const logoSrc = `${origin.replace(/\/$/, "")}/logo.png`;
   return (
-    <Html>
-      <Head />
-      <Preview>{`New Contact Submission — ${name}`}</Preview>
-      <Body
-        style={{
-          margin: 0,
-          padding: 0,
-          fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
-          backgroundColor: "#ffffff",
-          color: "#0f172a",
-        }}
+    <div
+      style={{
+        margin: 0,
+        padding: 0,
+        fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
+        backgroundColor: "#ffffff",
+        color: "#0f172a",
+      }}
+    >
+      <div
+        style={{ width: "100%", maxWidth: 640, margin: "0 auto", padding: 20 }}
       >
-        <Container
-          style={{
-            width: "100%",
-            maxWidth: 640,
-            margin: "0 auto",
-            padding: 20,
-          }}
-        >
-          <Section style={{ textAlign: "center", marginBottom: 12 }}>
-            <Img
-              src={logoSrc}
-              alt="Lazy Creations"
-              width={56}
-              height={56}
-              style={{ display: "inline-block", borderRadius: 8 }}
-            />
-          </Section>
-          <Section>
-            <Heading
-              as="h2"
-              style={{
-                margin: 0,
-                marginBottom: 10,
-                fontSize: 22,
-                color: "#111827",
-              }}
-            >
-              New Contact Submission
-            </Heading>
-            <Hr
-              style={{
-                border: 0,
-                height: 2,
-                backgroundColor: accent,
-                margin: "0 0 16px 0",
-              }}
-            />
-
-            <Text style={{ margin: 0, marginBottom: 8 }}>
-              <strong style={{ color: "#111827" }}>From:</strong> {name}
-            </Text>
-            <Text style={{ margin: 0, marginBottom: 8 }}>
-              <strong style={{ color: "#111827" }}>Email:</strong>{" "}
-              <Link href={`mailto:${email}`}>{email}</Link>
-            </Text>
-            {company ? (
-              <Text style={{ margin: 0, marginBottom: 8 }}>
-                <strong style={{ color: "#111827" }}>Company:</strong> {company}
-              </Text>
-            ) : null}
-            {phone ? (
-              <Text style={{ margin: 0, marginBottom: 8 }}>
-                <strong style={{ color: "#111827" }}>Phone:</strong> {phone}
-              </Text>
-            ) : null}
-            {budget ? (
-              <Text style={{ margin: 0, marginBottom: 8 }}>
-                <strong style={{ color: "#111827" }}>Budget:</strong> {budget}
-              </Text>
-            ) : null}
-
-            <Text
-              style={{
-                marginTop: 16,
-                marginBottom: 6,
-                color: "#111827",
-                fontWeight: 700,
-              }}
-            >
-              Message
-            </Text>
-            <Section
-              style={{
-                borderLeft: `4px solid ${accent}`,
-                backgroundColor: "#f9f9f9",
-                padding: "12px 14px",
-                borderRadius: 8,
-                whiteSpace: "pre-wrap",
-                color: "#111827",
-              }}
-            >
-              {message}
-            </Section>
-
-            <Text style={{ marginTop: 18, color: "#6b7280", fontSize: 12 }}>
-              Origin: {origin}
-            </Text>
-          </Section>
-
-          <Hr
+        <div style={{ textAlign: "center", marginBottom: 12 }}>
+          <img
+            src={logoSrc}
+            alt="Lazy Creations"
+            width={56}
+            height={56}
+            style={{ display: "inline-block", borderRadius: 8 }}
+          />
+        </div>
+        <div>
+          <h2
+            style={{
+              margin: 0,
+              marginBottom: 10,
+              fontSize: 22,
+              color: "#111827",
+            }}
+          >
+            New Contact Submission
+          </h2>
+          <div
             style={{
               border: 0,
-              height: 1,
-              backgroundColor: "#e5e7eb",
-              margin: "20px 0",
+              height: 2,
+              backgroundColor: accent,
+              margin: "0 0 16px 0",
             }}
           />
 
-          <Section style={{ textAlign: "center" }}>
-            <Text style={{ margin: 0, color: "#6b7280", fontSize: 12 }}>
-              © 2025 Lazy Creations LLC — Built with AI for SMBs ·{" "}
-              <Link href="https://lazycreations.ai" style={{ color: accent }}>
-                lazycreations.ai
-              </Link>
-            </Text>
-          </Section>
-        </Container>
-      </Body>
-    </Html>
+          <p style={{ margin: 0, marginBottom: 8 }}>
+            <strong style={{ color: "#111827" }}>From:</strong> {name}
+          </p>
+          <p style={{ margin: 0, marginBottom: 8 }}>
+            <strong style={{ color: "#111827" }}>Email:</strong>{" "}
+            <a href={`mailto:${email}`}>{email}</a>
+          </p>
+          {company ? (
+            <p style={{ margin: 0, marginBottom: 8 }}>
+              <strong style={{ color: "#111827" }}>Company:</strong> {company}
+            </p>
+          ) : null}
+          {phone ? (
+            <p style={{ margin: 0, marginBottom: 8 }}>
+              <strong style={{ color: "#111827" }}>Phone:</strong> {phone}
+            </p>
+          ) : null}
+          {budget ? (
+            <p style={{ margin: 0, marginBottom: 8 }}>
+              <strong style={{ color: "#111827" }}>Budget:</strong> {budget}
+            </p>
+          ) : null}
+
+          <p
+            style={{
+              marginTop: 16,
+              marginBottom: 6,
+              color: "#111827",
+              fontWeight: 700,
+            }}
+          >
+            Message
+          </p>
+          <div
+            style={{
+              borderLeft: `4px solid ${accent}`,
+              backgroundColor: "#f9f9f9",
+              padding: "12px 14px",
+              borderRadius: 8,
+              whiteSpace: "pre-wrap",
+              color: "#111827",
+            }}
+          >
+            {message}
+          </div>
+
+          <p style={{ marginTop: 18, color: "#6b7280", fontSize: 12 }}>
+            Origin: {origin}
+          </p>
+        </div>
+
+        <div
+          style={{
+            border: 0,
+            height: 1,
+            backgroundColor: "#e5e7eb",
+            margin: "20px 0",
+          }}
+        />
+
+        <div style={{ textAlign: "center" }}>
+          <p style={{ margin: 0, color: "#6b7280", fontSize: 12 }}>
+            © 2025 Lazy Creations LLC — Built with AI for SMBs ·{" "}
+            <a href="https://lazycreations.ai" style={{ color: accent }}>
+              lazycreations.ai
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/emails/ContactSubmission.tsx
+++ b/emails/ContactSubmission.tsx
@@ -8,6 +8,7 @@ type Props = {
   budget?: string;
   message: string;
   origin?: string;
+  logoUrl?: string;
 };
 
 const accent = "#00E5FF";
@@ -20,8 +21,19 @@ export default function ContactSubmissionEmail({
   budget,
   message,
   origin = "https://lazycreations.ai",
+  logoUrl,
 }: Props) {
-  const logoSrc = `${origin.replace(/\/$/, "")}/logo.png`;
+  const computedOrigin = origin.replace(/\/$/, "");
+  const isLocal = /localhost|127\.0\.0\.1|0\.0\.0\.0|192\.168\./.test(
+    computedOrigin,
+  );
+  const fallbackRemote = "https://lazycreations.ai/logo.png";
+  const logoSrc =
+    logoUrl && logoUrl.trim() !== ""
+      ? logoUrl
+      : isLocal
+        ? fallbackRemote
+        : `${computedOrigin}/logo.png`;
   return (
     <div
       style={{

--- a/emails/ContactSubmission.tsx
+++ b/emails/ContactSubmission.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import {
+  Html,
+  Head,
+  Preview,
+  Body,
+  Container,
+  Section,
+  Heading,
+  Text,
+  Img,
+  Hr,
+  Link,
+} from "@react-email/components";
+
+type Props = {
+  name: string;
+  email: string;
+  company?: string;
+  phone?: string;
+  budget?: string;
+  message: string;
+  origin?: string;
+};
+
+const accent = "#00E5FF";
+
+export default function ContactSubmissionEmail({
+  name,
+  email,
+  company,
+  phone,
+  budget,
+  message,
+  origin = "https://lazycreations.ai",
+}: Props) {
+  const logoSrc = `${origin.replace(/\/$/, "")}/logo.png`;
+  return (
+    <Html>
+      <Head />
+      <Preview>{`New Contact Submission — ${name}`}</Preview>
+      <Body
+        style={{
+          margin: 0,
+          padding: 0,
+          fontFamily: 'Arial, "Helvetica Neue", Helvetica, sans-serif',
+          backgroundColor: "#ffffff",
+          color: "#0f172a",
+        }}
+      >
+        <Container
+          style={{
+            width: "100%",
+            maxWidth: 640,
+            margin: "0 auto",
+            padding: 20,
+          }}
+        >
+          <Section style={{ textAlign: "center", marginBottom: 12 }}>
+            <Img
+              src={logoSrc}
+              alt="Lazy Creations"
+              width={56}
+              height={56}
+              style={{ display: "inline-block", borderRadius: 8 }}
+            />
+          </Section>
+          <Section>
+            <Heading
+              as="h2"
+              style={{
+                margin: 0,
+                marginBottom: 10,
+                fontSize: 22,
+                color: "#111827",
+              }}
+            >
+              New Contact Submission
+            </Heading>
+            <Hr
+              style={{
+                border: 0,
+                height: 2,
+                backgroundColor: accent,
+                margin: "0 0 16px 0",
+              }}
+            />
+
+            <Text style={{ margin: 0, marginBottom: 8 }}>
+              <strong style={{ color: "#111827" }}>From:</strong> {name}
+            </Text>
+            <Text style={{ margin: 0, marginBottom: 8 }}>
+              <strong style={{ color: "#111827" }}>Email:</strong>{" "}
+              <Link href={`mailto:${email}`}>{email}</Link>
+            </Text>
+            {company ? (
+              <Text style={{ margin: 0, marginBottom: 8 }}>
+                <strong style={{ color: "#111827" }}>Company:</strong> {company}
+              </Text>
+            ) : null}
+            {phone ? (
+              <Text style={{ margin: 0, marginBottom: 8 }}>
+                <strong style={{ color: "#111827" }}>Phone:</strong> {phone}
+              </Text>
+            ) : null}
+            {budget ? (
+              <Text style={{ margin: 0, marginBottom: 8 }}>
+                <strong style={{ color: "#111827" }}>Budget:</strong> {budget}
+              </Text>
+            ) : null}
+
+            <Text
+              style={{
+                marginTop: 16,
+                marginBottom: 6,
+                color: "#111827",
+                fontWeight: 700,
+              }}
+            >
+              Message
+            </Text>
+            <Section
+              style={{
+                borderLeft: `4px solid ${accent}`,
+                backgroundColor: "#f9f9f9",
+                padding: "12px 14px",
+                borderRadius: 8,
+                whiteSpace: "pre-wrap",
+                color: "#111827",
+              }}
+            >
+              {message}
+            </Section>
+
+            <Text style={{ marginTop: 18, color: "#6b7280", fontSize: 12 }}>
+              Origin: {origin}
+            </Text>
+          </Section>
+
+          <Hr
+            style={{
+              border: 0,
+              height: 1,
+              backgroundColor: "#e5e7eb",
+              margin: "20px 0",
+            }}
+          />
+
+          <Section style={{ textAlign: "center" }}>
+            <Text style={{ margin: 0, color: "#6b7280", fontSize: 12 }}>
+              © 2025 Lazy Creations LLC — Built with AI for SMBs ·{" "}
+              <Link href="https://lazycreations.ai" style={{ color: accent }}>
+                lazycreations.ai
+              </Link>
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@sendgrid/mail": "^8.1.6",
         "@vercel/analytics": "^1.5.0",
         "framer-motion": "^12.23.18",
         "gray-matter": "^4.0.3",
@@ -32,6 +33,7 @@
         "react-hook-form": "^7.63.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
+        "resend": "^4.8.0",
         "sonner": "^2.0.7",
         "zod": "^4.1.11"
       },
@@ -2293,6 +2295,24 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-email/render": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@react-email/render/-/render-1.1.2.tgz",
+      "integrity": "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==",
+      "license": "MIT",
+      "dependencies": {
+        "html-to-text": "^9.0.5",
+        "prettier": "^3.5.3",
+        "react-promise-suspense": "^0.3.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2306,6 +2326,57 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
     },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.120.4",
@@ -3782,6 +3853,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3806,6 +3883,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4058,7 +4146,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4489,6 +4576,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -4799,6 +4898,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4858,6 +4966,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4939,6 +5056,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -4956,7 +5128,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5052,6 +5223,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -5138,7 +5321,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5148,7 +5330,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5186,7 +5367,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5199,7 +5379,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6255,6 +6434,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6269,6 +6468,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/format": {
@@ -6352,7 +6567,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6416,7 +6630,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6450,7 +6663,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6591,7 +6803,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6707,7 +6918,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6720,7 +6930,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6736,7 +6945,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6811,6 +7019,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-errors": {
@@ -7830,6 +8073,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/legacy-javascript": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
@@ -8700,7 +8952,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9856,7 +10107,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -9869,7 +10119,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10561,6 +10810,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "license": "MIT",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10614,6 +10876,15 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -10753,7 +11024,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -10835,7 +11105,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -11012,6 +11281,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-promise-suspense": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
+      "integrity": "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/react-promise-suspense/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -11322,6 +11606,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/resend": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-4.8.0.tgz",
+      "integrity": "sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-email/render": "1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -11576,6 +11872,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "license": "MIT",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@sendgrid/mail": "^8.1.6",
     "@vercel/analytics": "^1.5.0",
     "framer-motion": "^12.23.18",
     "gray-matter": "^4.0.3",
@@ -45,6 +46,7 @@
     "react-hook-form": "^7.63.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
+    "resend": "^4.8.0",
     "sonner": "^2.0.7",
     "zod": "^4.1.11"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     ]
   },
   "dependencies": {
+    "@react-email/components": "^0.0.22",
+    "@react-email/render": "^0.0.16",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     ]
   },
   "dependencies": {
-    "@react-email/components": "^0.0.22",
     "@react-email/render": "^0.0.16",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     ]
   },
   "dependencies": {
-    "@react-email/render": "^0.0.16",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.10",


### PR DESCRIPTION
- Replace Formspree with POST /api/contact (validation, honeypot, rate‑limit); success only on provider OK
- Add /api/health/email; require RESEND_API_KEY + EMAIL_FROM/TO (optional SendGrid + EMAIL_LOGO_URL)
- Update all mailto links to admin@lazycreations.ai; improved form UX and email template logo fallback